### PR TITLE
:art: Create new translation page with index link

### DIFF
--- a/resources/views/admin/page/translations.blade.php
+++ b/resources/views/admin/page/translations.blade.php
@@ -2,12 +2,32 @@
 // @phpstan-ignore-next-line
 $model = $getRecord();
 $model->loadMissing('translationOriginModel.translations');
+$langs = $model->relationLoaded('translationOriginModel') && $model->translationOriginModel->relationLoaded('translations')
+    ? $model->translationOriginModel->translations->map(fn(\Webid\Druid\Models\Page $page) => $page->lang)->toArray()
+    : [];
 ?>
 @if($model->relationLoaded('translationOriginModel') && $model->translationOriginModel?->relationLoaded('translations'))
     <ul>
         @foreach($model->translationOriginModel->translations as $translation)
             <li><a href="/admin/pages/{{$translation->getKey()}}/edit">[{{ $translation->lang }}] {{$translation->title}}</a></li>
         @endforeach
+        @foreach(\Webid\Druid\Facades\Druid::getLocales() as $key => $locale)
+            @if(! in_array($key, $langs))
+                <div>
+                    <span>
+                       <a
+                           href="/admin/pages/create?lang={{$key}}&translation_origin_model_id={{$model->translationOriginModel->id}}&title={{$model->translationOriginModel->title}} [{{$key}}]"
+                           class="font-semibold text-sm text-custom-600 dark:text-custom-400 group-hover/link:underline group-focus-visible/link:underline"
+                           style="--c-400:var(--primary-400);--c-600:var(--primary-600);"
+                       >
+                        [{{ $key }}] créer la traduction
+                    </a>
+                    </span>
+
+                </div>
+            @endif
+        @endforeach
+
     </ul>
 @else
     <p>-</p>

--- a/src/Services/DefaultFilamentFieldsProvider.php
+++ b/src/Services/DefaultFilamentFieldsProvider.php
@@ -41,6 +41,9 @@ class DefaultFilamentFieldsProvider
         /** @var PageRepository $pageRepository */
         $pageRepository = app(PageRepository::class);
 
+        /** @var string|null $defaultTitle */
+        $defaultTitle = request()->input('title');
+
         $contentTab = [
             'title' => TextInput::make('title')
                 ->label(__('Title'))
@@ -49,13 +52,15 @@ class DefaultFilamentFieldsProvider
                     fn (string $operation, string $state, Set $set) => $operation === 'create'
                         ? $set('slug', Str::slug($state)) : null
                 )
+                ->default($defaultTitle ? $defaultTitle : null)
                 ->required(),
             $filamentComponentService->getFlexibleContentFieldsForModel(Page::class),
         ];
 
         $parametersTab = [
             'slug' => TextInput::make('slug')
-                ->label(__('Slug')),
+                ->label(__('Slug'))
+                ->default($defaultTitle ? Str::slug($defaultTitle) : null),
             'parent_page_id' => Select::make('parent_page_id')
                 ->label(__('Parent page'))
                 ->placeholder(__('Select a parent page'))
@@ -86,6 +91,7 @@ class DefaultFilamentFieldsProvider
                         )
                         ->required()
                         ->live()
+                        ->default(request()->input('lang') ? request()->input('lang') : null)
                         ->placeholder(__('Select a language')),
                     'translation_origin_model_id' => Select::make('translation_origin_model_id')
                         ->label(__('Translation origin model'))
@@ -108,6 +114,7 @@ class DefaultFilamentFieldsProvider
 
                             return $allDefaultLanguagePages;
                         })
+                        ->default(request()->input('translation_origin_model_id') ? request()->input('translation_origin_model_id') : null)
                         ->searchable()
                         ->hidden(fn (Get $get): bool => ! $get('lang') || $get('lang') === Druid::getDefaultLocale())
                         ->live(),


### PR DESCRIPTION
@benjaminniess j'ai essayé de pleins de façon de faire, mais ce fut un échec...
C'est ma dernière option, je ne sais vraiment pas ce que j'en pense...
Dis moi ce que toi tu en penses.

ça ressemble à ceci sur la liste :

<img width="860" alt="Capture d’écran 2025-06-13 à 12 14 01" src="https://github.com/user-attachments/assets/5f3eabb1-8a40-4756-873c-3af7f48cfc22" />


Et lorsque tu cliques sur créer la traduction pour une langue, tu tombes sur la page de création avec le titre, le slug, la langue et le Translation origin model de pré-rempli :

<img width="1273" alt="Capture d’écran 2025-06-13 à 12 13 50" src="https://github.com/user-attachments/assets/c6768c0b-d4d9-4921-86a7-dbe6cbd7c4ed" />
<img width="1234" alt="Capture d’écran 2025-06-13 à 12 13 55" src="https://github.com/user-attachments/assets/af15c89d-2b74-4502-8c47-547379dba40c" />

